### PR TITLE
ApiPresenter: scheme filepath is without modules, only presenter is used

### DIFF
--- a/src/ApiPresenter.php
+++ b/src/ApiPresenter.php
@@ -331,6 +331,8 @@ abstract class ApiPresenter implements Nette\Application\IPresenter
 	{
 		$ref = new ClassType($this);
 		$path = str_replace('presenters', 'schemas', dirname($ref->fileName));
+		$presenter = explode(':', $presenter);
+		$presenter = end($presenter);
 		return array(
 			$path . '/'. str_replace(':', '/', $presenter) . '/' . $action . '.json'
 		);


### PR DESCRIPTION
Funkce `formatSchemaFiles` hledá schémata ve složce podle presenteru. Např. z `Api:Bikes:search` se stane `Api/Bikes/search.json`, ta první část je název modulu a protože již jsme ve složce ApiModule, myslím, že je zbytečné to opakovat. Toto teda asi lepší, ne?

// cc @paranoiq

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/clevis/restapibase/3)

<!-- Reviewable:end -->
